### PR TITLE
Feature: 만료된 refresh token 삭제 스케줄러 추가

### DIFF
--- a/src/main/kotlin/com/sokdak/SokdakApplication.kt
+++ b/src/main/kotlin/com/sokdak/SokdakApplication.kt
@@ -3,9 +3,11 @@ package com.sokdak
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 @EnableAsync
+@EnableScheduling
 class SokdakApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/sokdak/auth/adapter/outbound/schedulers/RefreshTokenCleanupScheduler.kt
+++ b/src/main/kotlin/com/sokdak/auth/adapter/outbound/schedulers/RefreshTokenCleanupScheduler.kt
@@ -1,0 +1,20 @@
+package com.sokdak.auth.adapter.outbound.schedulers
+
+import com.sokdak.auth.domain.repositories.RefreshTokenRepository
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class RefreshTokenCleanupScheduler(
+    private val refreshTokenRepository: RefreshTokenRepository,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul") // 매일 새벽 3시 KST
+    fun cleanupExpiredTokens() {
+        logger.info("Starting expired refresh token cleanup")
+        refreshTokenRepository.deleteExpiredTokens()
+        logger.info("Completed expired refresh token cleanup")
+    }
+}


### PR DESCRIPTION
### 관련 이슈 
https://github.com/jieunpark626/sokdak/issues/16#issue-3845776299

### 요약
- 만료된 refresh token을 자동으로 정리하는 스케줄러 추가                        
- 매일 새벽 3시(KST)에 실행되어 DB에 쌓이는 만료 토큰 정리                      
                                                                                  
### Changes                                                                                                                                      
- SokdakApplication.kt: @EnableScheduling 추가                                  
- RefreshTokenCleanupScheduler.kt: 스케줄러 클래스 신규 생성                                                          